### PR TITLE
Add cave location for Elder Meadowrun. Add Dragon Isles and Khaz Algar

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -29,6 +29,8 @@ local continents = {
 	[875] = true, -- Zandalar
 	[876] = true, -- Kul Tiras
 	[947] = true, -- Azeroth
+	[1978] = true, -- Dragon Isles
+	[2274] = true, -- Khaz Algar
 }
 
 local notes = {
@@ -43,6 +45,7 @@ local notes = {
 	[8715]  = "Speak to Zidormi in Darkshore to gain access to Teldrassil.",
 	[8718]  = "Speak to Zidormi in Darkshore to gain access to Darnassus.",
 	[8721]  = "Speak to Zidormi in Darkshore to gain access to Lor'danel.",
+	[8722]  = "Enter the cave at 65.3 38.6.", -- Elder Meadowrun, Western Plaguelands
 	[8727]  = "Inside the dungeon.", -- Elder Farwhisper, Stratholme
 	[13017] = "Inside the dungeon.", -- Elder Jarten, Utgarde Keep
 	[13021] = "Inside the dungeon.", -- Elder Igasho, The Nexus

--- a/Data.lua
+++ b/Data.lua
@@ -319,3 +319,51 @@ points[249] = { -- "Uldum"
 points[205] = { -- "VashjirRuins"
 	[57268615] = { 29738, 6006, 8 }, -- Elder Moonlance
 }
+
+
+----------------------
+-- The Dragon Isles --
+----------------------
+points[2022] = {
+	[46703094] = { 73848, 17321, 1 }, -- Iskaara Elder Shomkol
+	[44306379] = { 73716, 17321, 2 }, -- Aylaag Elder
+}
+
+points[2023] = {
+	[83934803] = { 73172, 17321, 3 }, -- Shikaar Elder
+	[58393146] = { 73717, 17321, 4 }, -- Ohn'ir Elder
+}
+
+points[2024] = {
+	[12894905] = { 73858, 17321, 5 }, -- Iskaara Elder Nemaglek
+	[67424949] = { 73860, 17321, 6 }, -- Elder Dekidig
+}
+
+points[2025] = {
+	[54864337] = { 73859, 17321, 7 }, -- Iskaara Elder Sik'ek
+	[50056654] = { 73861, 17321, 8 }, -- Elder Razlok
+}
+
+
+----------------
+-- Khaz Algar --
+----------------
+points[2248] = {
+	[40908740] = { 85929, 41130, 1 }, -- Archivist Rubbleglint
+	[48621396] = { 85930, 41130, 2 }, -- Archivist Coppermoss
+}
+
+points[2214] = {
+	[48916730] = { 85931, 41130, 3 }, -- Archivist Farolt
+	[67295298] = { 85932, 41130, 4 }, -- Archivist Silsigra
+}
+
+points[2215] = {
+	[25885193] = { 85933, 41130, 5 }, -- Elder Knythall
+	[66274628] = { 85934, 41130, 6 }, -- Elder Swornvow
+}
+
+points[2255] = {
+	[66908554] = { 85935, 41130, 7 }, -- Elder Ikk'zivan
+	[46835720] = { 85936, 41130, 8 }, -- Elder Ikk'xataz
+}

--- a/Data.lua
+++ b/Data.lua
@@ -47,7 +47,7 @@ points[23] = { -- "EasternPlaguelands"
 }
 
 points[37] = { -- "Elwynn"
-	[34565026] = { 8646, 915, 3 }, -- Elder Hammershout
+	[32135280] = { 8646, 915, 3 }, -- Elder Hammershout
 	[39796367] = { 8649, 912, 3 }, -- Elder Stormbrow
 }
 

--- a/HandyNotes_LunarFestival.toc
+++ b/HandyNotes_LunarFestival.toc
@@ -1,4 +1,4 @@
-## Interface: 90005
+## Interface: 110007
 ## Title: HandyNotes_LunarFestival
 ## Notes: Displays the locations of Lunar Festival elders.
 ## Author: Ravendwyr

--- a/HandyNotes_LunarFestival.toc
+++ b/HandyNotes_LunarFestival.toc
@@ -1,4 +1,4 @@
-## Interface: 110007
+## Interface: 110100
 ## Title: HandyNotes_LunarFestival
 ## Notes: Displays the locations of Lunar Festival elders.
 ## Author: Ravendwyr


### PR DESCRIPTION
This update adds the Dragon Isles and Khaz Algar elders, adds a tooltip for the cave entrance for Elder Meadowrun, and moves Eldar Hammershout location due to location of Love is in the Air event placement outside of Stormwind.